### PR TITLE
Prevent POST URL from overriding, redirect to login with error box

### DIFF
--- a/Customer/src/main/java/com/ecommerce/customer/controller/LoginController.java
+++ b/Customer/src/main/java/com/ecommerce/customer/controller/LoginController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
@@ -34,10 +35,11 @@ public class LoginController {
     }
 
 
-    @PostMapping("/do-register")
+    @PostMapping("/register")
     public String registerCustomer(@Valid @ModelAttribute("customerDto") CustomerDto customerDto,
                                    BindingResult result,
-                                   Model model) {
+                                   Model model,
+                                   RedirectAttributes redirectAttributes) {
         try {
             if (result.hasErrors()) {
                 model.addAttribute("customerDto", customerDto);
@@ -53,7 +55,7 @@ public class LoginController {
             if (customerDto.getPassword().equals(customerDto.getConfirmPassword())) {
                 customerDto.setPassword(passwordEncoder.encode(customerDto.getPassword()));
                 customerService.save(customerDto);
-                model.addAttribute("success", "Register successfully!");
+                redirectAttributes.addFlashAttribute("success", "Register successfully!");
             } else {
                 model.addAttribute("error", "Password is incorrect");
                 model.addAttribute("customerDto", customerDto);
@@ -63,7 +65,7 @@ public class LoginController {
             e.printStackTrace();
             model.addAttribute("error", "Server is error, try again later!");
         }
-        return "register";
+        return "redirect:/login";
     }
 
 

--- a/Customer/src/main/resources/templates/login.html
+++ b/Customer/src/main/resources/templates/login.html
@@ -30,6 +30,9 @@
         <div class="noi-dung">
             <div class="form">
                 <h2>Log In</h2>
+                <div th:if = "${success}">
+                    <p class = "alert alert-success" th:text = "${success}"></p>
+                </div>
                 <div th:if = "${param.error}" class="alert alert-danger text-center">
                     Invalid username or password
                 </div>

--- a/Customer/src/main/resources/templates/register.html
+++ b/Customer/src/main/resources/templates/register.html
@@ -29,7 +29,7 @@
                 <div th:if = "${error}">
                     <p class = "alert alert-danger" th:text = "${error}"></p>
                 </div>
-                <form th:action = "@{/do-register}" method="POST" th:object = "${customerDto}">
+                <form th:action = "@{/register}" method="post" th:object = "${customerDto}">
                     <div class="input-form">
                         <div class="input-form">
                             <input type="text" placeholder="First Name" name="firstname" th:field = "*{firstName}" required>


### PR DESCRIPTION
**- Prevent POST URL from overriding:** 
The problem stems from POST URL conflicting with the GET URL mapping for /register https://stackoverflow.com/questions/53519006/spring-is-it-possible-to-give-same-url-path-in-request-mapping-for-two-diffe

**- Redirect to login with error box:** 
Using redirectAttributes.addFlashAttribute() can carry the attribute across the urls https://stackoverflow.com/questions/14470111/spring-redirectattributes-addattribute-vs-addflashattribute